### PR TITLE
Fix: add transform methods to resolve torchvision dependency issue

### DIFF
--- a/engine/data/transforms/_transforms.py
+++ b/engine/data/transforms/_transforms.py
@@ -66,6 +66,9 @@ class PadToSize(T.Pad):
         self.size = size
         super().__init__(0, fill, padding_mode)
 
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return self._transform(inpt, params)
+    
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         fill = self._fill[type(inpt)]
         padding = params['padding']
@@ -101,6 +104,9 @@ class ConvertBoxes(T.Transform):
         self.fmt = fmt
         self.normalize = normalize
 
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return self._transform(inpt, params)
+    
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         spatial_size = getattr(inpt, _boxes_keys[1])
         if self.fmt:
@@ -124,6 +130,9 @@ class ConvertPILImage(T.Transform):
         self.dtype = dtype
         self.scale = scale
 
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return self._transform(inpt, params)
+    
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         inpt = F.pil_to_tensor(inpt)
         if self.dtype == 'float32':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-torch>=2.0.1
-torchvision==0.20.1
+torch
+torchvision
 faster-coco-eval>=1.6.5
 PyYAML
 tensorboard


### PR DESCRIPTION
## Summary
This PR adds `transform()` methods to address issues caused by changes in torchvision versions.  
The project previously required `torchvision==0.20.1` in `requirements.txt`.  
After torchvision 0.21.0, `_transform()` method has been publicly exposed, which lead to raise NotImplementedError.

With this PR:
- The code works with the latest torchvision (0.24.1) and torch (2.9.1)
- Users can upgrade to newer `torch`, `torchvision` versions without runtime errors

Related Links:
- Similar PR addressing this problem: [DEIM PR #104](https://github.com/Intellindust-AI-Lab/DEIM/pull/104)
- Torchvision release log that publicly expose `_transform()` method: [Torchvision PR #8787](https://github.com/pytorch/vision/pull/8787)

## Changes
- Added `transform()` methods that returns current `_transform()` implementation
- Updated function calls to ensure compatibility with torchvision >= 0.21.0

## Test Environment
- Python: 3.11.9
- Torch: 2.9.1
- Torchvision: 0.24.1

## Error Message
<details>
<summary>Click to expand the full traceback</summary>

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/user/workspace/RT-DETRv4/train.py", line 84, in <module>
[rank0]:     main(args)
[rank0]:   File "/home/user/workspace/RT-DETRv4/train.py", line 54, in main
[rank0]:     solver.fit()
[rank0]:   File "/home/user/workspace/RT-DETRv4/engine/solver/det_solver.py", line 77, in fit
[rank0]:     train_stats, grad_percentages = train_one_epoch(
[rank0]:                                     ^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/workspace/RT-DETRv4/engine/solver/det_engine.py", line 64, in train_one_epoch
[rank0]:     for i, (samples, targets) in enumerate(metric_logger.log_every(data_loader, print_freq, header)):
[rank0]:   File "/home/user/workspace/RT-DETRv4/engine/misc/logger.py", line 215, in log_every
[rank0]:     for obj in iterable:
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/utils/data/dataloader.py", line 732, in __next__
[rank0]:     data = self._next_data()
[rank0]:            ^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/utils/data/dataloader.py", line 1506, in _next_data
[rank0]:     return self._process_data(data, worker_id)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/utils/data/dataloader.py", line 1541, in _process_data
[rank0]:     data.reraise()
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/_utils.py", line 769, in reraise
[rank0]:     raise exception
[rank0]: NotImplementedError: Caught NotImplementedError in DataLoader worker process 0.
[rank0]: Original Traceback (most recent call last):
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/utils/data/_utils/worker.py", line 349, in _worker_loop
[rank0]:     data = fetcher.fetch(index)  # type: ignore[possibly-undefined]
[rank0]:            ^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/utils/data/_utils/fetch.py", line 52, in fetch
[rank0]:     data = [self.dataset[idx] for idx in possibly_batched_index]
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/utils/data/_utils/fetch.py", line 52, in <listcomp>
[rank0]:     data = [self.dataset[idx] for idx in possibly_batched_index]
[rank0]:             ~~~~~~~~~~~~^^^^^
[rank0]:   File "/home/user/workspace/RT-DETRv4/engine/data/dataset/coco_dataset.py", line 44, in __getitem__
[rank0]:     img, target, _ = self._transforms(img, target, self)
[rank0]:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/workspace/RT-DETRv4/engine/data/transforms/container.py", line 58, in forward
[rank0]:     return self.get_forward(self.policy['name'])(*inputs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/workspace/RT-DETRv4/engine/data/transforms/container.py", line 100, in stop_epoch_forward
[rank0]:     sample = transform(sample)
[rank0]:              ^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torchvision/transforms/v2/_transform.py", line 68, in forward
[rank0]:     flat_outputs = [
[rank0]:                    ^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torchvision/transforms/v2/_transform.py", line 69, in <listcomp>
[rank0]:     self.transform(inpt, params) if needs_transform else inpt
[rank0]:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/user/anaconda3/envs/rtv4/lib/python3.11/site-packages/torchvision/transforms/v2/_transform.py", line 55, in transform
[rank0]:     raise NotImplementedError
[rank0]: NotImplementedError
```

</details>